### PR TITLE
CONNECTOR-915 Support Info Requests + Whitelisting

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/proto/src/main/proto/kvs.proto
+++ b/proto/src/main/proto/kvs.proto
@@ -139,6 +139,9 @@ message AerospikeRequestPayload {
 
   // Request for getting background task status.
   optional BackgroundTaskStatusRequest backgroundTaskStatusRequest = 10;
+
+  // Info request
+  optional InfoRequest infoRequest = 11;
 }
 
 // The request message containing the user's name.
@@ -785,5 +788,26 @@ service Query {
 
   // Get status of a stream of background tasks.
   rpc BackgroundTaskStatusStreaming(stream AerospikeRequestPayload) returns
+      (stream AerospikeResponsePayload) {}
+}
+
+// Info policy for info request
+message InfoPolicy {
+  // Info command socket timeout in milliseconds.
+  //
+  // Default: 1000
+  optional uint32 timeout = 1;
+}
+
+// Info request
+message InfoRequest {
+  optional InfoPolicy infoPolicy = 1;
+  repeated string commands = 2;
+}
+
+// Aerospike info requests
+service Info {
+  // Send an info request
+  rpc Info (AerospikeRequestPayload) returns
       (stream AerospikeResponsePayload) {}
 }

--- a/proto/src/main/proto/kvs.proto
+++ b/proto/src/main/proto/kvs.proto
@@ -809,5 +809,5 @@ message InfoRequest {
 service Info {
   // Send an info request
   rpc Info (AerospikeRequestPayload) returns
-      (stream AerospikeResponsePayload) {}
+      (AerospikeResponsePayload) {}
 }

--- a/stub/build.gradle.kts
+++ b/stub/build.gradle.kts
@@ -10,7 +10,7 @@ apply(plugin = "com.google.protobuf")
 apply(plugin = "com.google.protobuf")
 
 dependencies {
-    protobuf("com.aerospike:aerospike-proxy-proto:1.0.0")
+    protobuf("com.aerospike:aerospike-proxy-proto:1.0.1-SNAPSHOT")
     api(
         "com.google.protobuf:protobuf-java:${
             project


### PR DESCRIPTION
It's a draft PR, before merge its required to publish a new proto version (`aerospike-proxy-proto:1.0.1`) and use it as a dependency in the stub `build.gradle.kts` (I built locally and used 1.0.1-SNAPSHOT locally).