### PR TITLE
Fix enum param order

### DIFF
--- a/proto/src/main/proto/kvs.proto
+++ b/proto/src/main/proto/kvs.proto
@@ -76,11 +76,11 @@ enum Replica {
 }
 
 enum QueryDuration {
-    // The query is expected to return less than 100 records per node. The server optimizes for a small record set.
-    SHORT = 0;
-
     // The query is expected to return more than 100 records per node. The server optimizes for a large record set.
-    LONG = 1;
+    LONG = 0;
+
+    // The query is expected to return less than 100 records per node. The server optimizes for a small record set.
+    SHORT = 1;
 
     // Treat query as a LONG query, but relax read consistency for AP namespaces.
     // This value is treated exactly like LONG for server versions &lt; 7.1.


### PR DESCRIPTION
Fix enum param order, QueryDuration.LONG should be the default.